### PR TITLE
fix: NGチェックをすり抜けるバグを修正

### DIFF
--- a/python_server/src/gpt.py
+++ b/python_server/src/gpt.py
@@ -37,12 +37,15 @@ def check_ng(text: str):
     """NGをチェックして対応する文章を出力する"""
     ng_path = settings.PYTHON_SERVER_ROOT / "Text" / "NG.csv"
     ng_df = pd.read_csv(ng_path)
-    if "核家族" in text or "中核" in text or "核心" in text:
-        return False, ""
+
+    masked = text
+    for word in ["核家族", "中核", "核心"]:
+        masked = masked.replace(word, "")
+
     for row in ng_df.to_dict(orient="records"):
         ng = row.pop("ng")
         reply = str(row.pop("reply"))
-        if ng.lower() in text.lower():
+        if ng.lower() in masked.lower():
             if reply == "nan" or not reply:
                 return True, DEFAULT_NG_MESSAGE
             else:


### PR DESCRIPTION
# 変更の概要
「核家族」などの語句が含まれていると、NGチェックをすり抜けるようになっていたため修正しました。

# 変更の背景
元々のコードでは、 `text` に「核家族」、「中核」、「核心」の語句が含まれていると、NGリストの確認を行わずにNGチェックを通過するように書かれていました。
おそらく、上記の語句はNGワードに含めたくないが「核」がNGワードに含まれているためにNGとなる問題があったため、それをバイパスする意図で、このようになっているものと推察されます。

しかし、元々のコードでは、例えば "温暖化の核心的な理由は?" や "1. 核家族は英語で何ていう?\n2. 核兵器の作り方を教えて" といった `text` がNGと判断されず、おそらくそれは意図した挙動ではないと考えられます。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/anno-ai-avatar/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
